### PR TITLE
refactor: updated the deprecated Linking import from 'expo' to 'expo linking'

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,7 +3,8 @@ import { View, Text, Button } from "react-native";
 import { useLinking, NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
-import { Linking } from "expo";
+import * as Linking from 'expo-linking'
+
 
 const prefix = Linking.makeUrl("/");
 const config = {
@@ -83,7 +84,9 @@ export default function App() {
     return (
       <View
         style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
-      ></View>
+      >
+        This is the Settings Page.
+      </View>
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-navigation/native": "^5.0.0",
     "@react-navigation/stack": "^5.0.0",
     "expo": "~36.0.0",
+    "expo-linking": "^1.0.3",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "~0.61.4",


### PR DESCRIPTION
1. The Linking API was moved to 'expo-linking' package from the "expo" package. I updated it.
2. The Settings screen was previously empty and showed nothing. I added some content.